### PR TITLE
Icone de config dans ecrire/?exec=admin_plugin 

### DIFF
--- a/paquet.xml
+++ b/paquet.xml
@@ -1,6 +1,6 @@
 <paquet prefix="souscription"
         categorie="communication"
-        version="2.4.15"
+        version="2.4.16"
         etat="test"
         compatibilite="[3.0.5;3.0.*]"
         logo="souscription-32.png"
@@ -39,5 +39,5 @@
         titre="souscription:titre_configurer_souscriptions"
         parent="menu_configuration"
         icone="images/souscription-16.png"
-        action="configurer_souscriptions"/>
+        action="configurer_souscription"/>
 </paquet>

--- a/prive/squelettes/contenu/configurer_souscriptions.html
+++ b/prive/squelettes/contenu/configurer_souscriptions.html
@@ -1,7 +1,0 @@
-[(#AUTORISER{configurer,souscription}|sinon_interdire_acces)]
-
-<h1 class="grostitre"><:souscription:titre_page_configurer_souscriptions:></h1>
-
-<div class="ajax">
-	#FORMULAIRE_CONFIGURER_SOUSCRIPTION
-</div>


### PR DESCRIPTION
De l'utilité d'écrire une doc et de s'étonner de ne pas voir apparaitre l'icone de configuration du plugin sur la page ecrire/?exec=admin_plugin
