### PR TITLE
Pouvoir choisir une liste de diffusion spécifique aux souscripteurs

### DIFF
--- a/formulaires/configurer_souscription.html
+++ b/formulaires/configurer_souscription.html
@@ -134,6 +134,10 @@
 						<label for="#GET{name}_#GET{val}"><:souscription:label_proposer_infolettre:></label>
 					</div>
 				</li>
+        <li class="editer long_label">
+            <label for="mailing_list">Choix de liste de diffusion</label>
+            <input type="text" class="text email" name="mailing_list" value="#ENV{mailing_list,newsletter}">
+        </li>
 			</ul>
 		</fieldset>
 		<fieldset>

--- a/formulaires/souscription.php
+++ b/formulaires/souscription.php
@@ -355,7 +355,10 @@ function formulaires_souscription_traiter_dist($id_souscription_campagne){
 		$nom = array(_request("prenom"),_request("nom"));
 		$nom = array_filter($nom);
 		$nom = implode(" ",$nom);
-		$subscribe($email,array('nom'=>$nom));
+		$subscribe($email,array(
+				'nom'=>$nom,
+				'listes'=> explode(',',lire_config("souscription/mailing_list"))
+		));
 	}
 
 	return $ret;


### PR DESCRIPTION
Bonjour,

Sur le projet ou j'intègre le plugin, on s'est posé la question de créer une liste juste pour les souscripteurs, et pouvoir les tenir au jus de l'évolution du projet (genre crowfunding).

Donc l'idée c'est de pouvoir choisir une (ou plusieurs) liste de diffusion 

Je suis passé par une config générale ajouté au panneau de config (donc pas de liste par campagnes).

on peut en passer plusieurs si besoin (identifiant1,newsletter2)

ç'est une proposition (j'ai pas ajouté les chaines de langues, etc …), je ne sais pas si c'est ainsi que ça doit être intégré au plugin…

