### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/souscription_autorisations.php
+++ b/souscription_autorisations.php
@@ -84,10 +84,10 @@ function autoriser_souscription_exporter_dist($faire, $type, $id, $qui, $opt) {
   return autoriser('webmestre', '', '', $qui);
 }
 
-function autoriser_souscription_configurer_dist($faire, $mode='', $id=0, $qui = NULL, $opt = NULL){
+function autoriser_souscription_configurer_dist($faire, $mode='', $id=0, $qui = null, $opt = null){
   return autoriser('webmestre');
 }
 
-function autoriser_souscriptioncampagne_dist($faire, $mode='', $id=0, $qui = NULL, $opt = NULL){
+function autoriser_souscriptioncampagne_dist($faire, $mode='', $id=0, $qui = null, $opt = null){
   return autoriser('webmestre');
 }


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!